### PR TITLE
fix: text stream animation jank

### DIFF
--- a/web/src/components/chat/ChatMessages.tsx
+++ b/web/src/components/chat/ChatMessages.tsx
@@ -22,6 +22,7 @@ interface Props {
   messages: Array<components["schemas"]["ChatRsMessage"]>;
   streamedResponse?: string;
   error?: string;
+  sessionId?: string;
 }
 
 const proseClasses =
@@ -32,6 +33,7 @@ const proseAssistantClasses = "prose-code:text-secondary-foreground";
 export default function ChatMessages({
   user,
   messages,
+  sessionId,
   isGenerating,
   isCompleted,
   streamedResponse,
@@ -48,13 +50,16 @@ export default function ChatMessages({
   useEffect(() => {
     if (!streamedResponse) reset();
   }, [streamedResponse, reset]);
+  useEffect(() => {
+    if (sessionId) reset();
+  }, [sessionId, reset]);
 
   const { mutate: deleteMessage } = useDeleteChatMessage();
   const onDeleteMessage = useCallback(
-    (sessionId: string, messageId: string) => {
-      deleteMessage({ sessionId, messageId });
+    (messageId: string) => {
+      sessionId && deleteMessage({ sessionId, messageId });
     },
-    [deleteMessage],
+    [deleteMessage, sessionId],
   );
 
   return (
@@ -92,11 +97,7 @@ export default function ChatMessages({
                 <div className="flex items-center gap-2 opacity-65 hover:opacity-100 focus-within:opacity-100">
                   <InfoButton meta={message.meta} />
                   <CopyButton message={message.content} />
-                  <DeleteButton
-                    onDelete={() =>
-                      onDeleteMessage(message.session_id, message.id)
-                    }
-                  />
+                  <DeleteButton onDelete={() => onDeleteMessage(message.id)} />
                 </div>
               )}
             </ChatBubbleMessage>

--- a/web/src/hooks/useSmoothStreaming.ts
+++ b/web/src/hooks/useSmoothStreaming.ts
@@ -175,6 +175,13 @@ export function useSmoothStreaming(
       lastStreamLengthRef.current = newLength;
       lastStreamTimeRef.current = now;
 
+      // If previous stream length was empty and newLength is big,
+      // we might be switching to an ongoing stream. Skip ahead to the
+      // current position instead of animating all of the characters so far.
+      if (prevLength === 0 && newLength > 100) {
+        positionRef.current = bufferRef.current.length - 2;
+      }
+
       // Start or resume streaming
       if (!isStreaming && timeoutRef.current === null) {
         setIsStreaming(true);

--- a/web/src/routes/app/_appLayout/session/$sessionId.tsx
+++ b/web/src/routes/app/_appLayout/session/$sessionId.tsx
@@ -43,6 +43,7 @@ function RouteComponent() {
       <ChatMessages
         user={user}
         messages={data?.messages || []}
+        sessionId={sessionId}
         error={streamedChats[sessionId]?.error}
         streamedResponse={streamedChats[sessionId]?.content}
         isGenerating={


### PR DESCRIPTION
This fixes the streaming animation restarting when switching between ongoing chats, and not properly updating state in some cases.