### PR TITLE
feat: full text search & update session updated_at on new messages

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -37,14 +37,6 @@
       "code_actions_on_format": {
         "source.fixAll.biome": true
       }
-    },
-    "SQL": {
-      "formatter": {
-        "external": {
-          "command": "sql-formatter",
-          "arguments": ["--language", "postgresql"]
-        }
-      }
     }
   }
 }

--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -37,6 +37,14 @@
       "code_actions_on_format": {
         "source.fixAll.biome": true
       }
+    },
+    "SQL": {
+      "formatter": {
+        "external": {
+          "command": "sql-formatter",
+          "arguments": ["--language", "postgresql"]
+        }
+      }
     }
   }
 }

--- a/server/migrations/2025-06-21-031403_full_text_search/down.sql
+++ b/server/migrations/2025-06-21-031403_full_text_search/down.sql
@@ -1,7 +1,10 @@
 DROP TRIGGER chat_sessions_search_vector_update on chat_sessions;
+
 DROP TRIGGER chat_messages_search_vector_update on chat_messages;
 
 DROP FUNCTION chat_sessions_search_vector_update;
+
 DROP FUNCTION chat_messages_search_vector_update;
 
-ALTER TABLE chat_messages DROP COLUMN search_vector;
+ALTER TABLE chat_messages
+DROP COLUMN search_vector;

--- a/server/migrations/2025-06-21-031403_full_text_search/down.sql
+++ b/server/migrations/2025-06-21-031403_full_text_search/down.sql
@@ -1,0 +1,7 @@
+DROP TRIGGER chat_sessions_search_vector_update on chat_sessions;
+DROP TRIGGER chat_messages_search_vector_update on chat_messages;
+
+DROP FUNCTION chat_sessions_search_vector_update;
+DROP FUNCTION chat_messages_search_vector_update;
+
+ALTER TABLE chat_messages DROP COLUMN search_vector;

--- a/server/migrations/2025-06-21-031403_full_text_search/up.sql
+++ b/server/migrations/2025-06-21-031403_full_text_search/up.sql
@@ -1,35 +1,53 @@
-ALTER TABLE chat_messages ADD COLUMN search_vector tsvector NOT NULL DEFAULT '';
+ALTER TABLE chat_messages
+ADD COLUMN search_vector tsvector NOT NULL DEFAULT '';
 
 CREATE INDEX chat_messages_search_vector_idx ON chat_messages USING GIN (search_vector);
 
 UPDATE chat_messages
-SET search_vector = setweight(to_tsvector('english', (
-    SELECT title FROM chat_sessions WHERE id = session_id
-)), 'A') || setweight(to_tsvector('english', "content"), 'B');
+SET
+  search_vector = setweight(
+    to_tsvector(
+      'english',
+      (
+        SELECT
+          title
+        FROM
+          chat_sessions
+        WHERE
+          id = session_id
+      )
+    ),
+    'A'
+  ) || setweight(to_tsvector('english', "content"), 'B');
 
-CREATE OR REPLACE FUNCTION chat_messages_search_vector_update() RETURNS trigger AS $$
+CREATE OR REPLACE FUNCTION chat_messages_search_vector_update () RETURNS trigger AS $$
 BEGIN
     NEW.search_vector :=
-        setweight(to_tsvector('english', (SELECT title FROM chat_sessions
-	WHERE id = NEW.session_id)), 'A') || setweight(to_tsvector('english', NEW."content"), 'B');
+        setweight(to_tsvector('english', (
+            SELECT title FROM chat_sessions WHERE id = NEW.session_id
+        )), 'A') || setweight(to_tsvector('english', NEW."content"), 'B');
     RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION chat_sessions_search_vector_update() RETURNS trigger AS $$
+CREATE OR REPLACE FUNCTION chat_sessions_search_vector_update () RETURNS trigger AS $$
 	BEGIN
 		IF old.title = new.title THEN RETURN NEW; END IF;
-		UPDATE chat_messages SET search_vector =
+		UPDATE chat_messages
+		SET search_vector =
 	        setweight(to_tsvector('english', NEW.title), 'A') || setweight(to_tsvector('english', "content"), 'B')
-	       WHERE session_id = NEW.id;
+	    WHERE session_id = NEW.id;
 	    RETURN NEW;
 	END;
 $$ LANGUAGE plpgsql;
 
-CREATE TRIGGER chat_messages_search_vector_update
-BEFORE INSERT OR UPDATE ON chat_messages
-FOR EACH ROW EXECUTE FUNCTION chat_messages_search_vector_update();
+CREATE TRIGGER chat_messages_search_vector_update BEFORE INSERT
+OR
+UPDATE ON chat_messages FOR EACH ROW
+EXECUTE FUNCTION chat_messages_search_vector_update ();
 
 CREATE TRIGGER chat_sessions_search_vector_update
-AFTER INSERT OR UPDATE ON chat_sessions
-FOR EACH ROW EXECUTE FUNCTION chat_sessions_search_vector_update();
+AFTER INSERT
+OR
+UPDATE ON chat_sessions FOR EACH ROW
+EXECUTE FUNCTION chat_sessions_search_vector_update ();

--- a/server/migrations/2025-06-21-031403_full_text_search/up.sql
+++ b/server/migrations/2025-06-21-031403_full_text_search/up.sql
@@ -1,0 +1,35 @@
+ALTER TABLE chat_messages ADD COLUMN search_vector tsvector NOT NULL DEFAULT '';
+
+CREATE INDEX chat_messages_search_vector_idx ON chat_messages USING GIN (search_vector);
+
+UPDATE chat_messages
+SET search_vector = setweight(to_tsvector('english', (
+    SELECT title FROM chat_sessions WHERE id = session_id
+)), 'A') || setweight(to_tsvector('english', "content"), 'B');
+
+CREATE OR REPLACE FUNCTION chat_messages_search_vector_update() RETURNS trigger AS $$
+BEGIN
+    NEW.search_vector :=
+        setweight(to_tsvector('english', (SELECT title FROM chat_sessions
+	WHERE id = NEW.session_id)), 'A') || setweight(to_tsvector('english', NEW."content"), 'B');
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION chat_sessions_search_vector_update() RETURNS trigger AS $$
+	BEGIN
+		IF old.title = new.title THEN RETURN NEW; END IF;
+		UPDATE chat_messages SET search_vector =
+	        setweight(to_tsvector('english', NEW.title), 'A') || setweight(to_tsvector('english', "content"), 'B')
+	       WHERE session_id = NEW.id;
+	    RETURN NEW;
+	END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER chat_messages_search_vector_update
+BEFORE INSERT OR UPDATE ON chat_messages
+FOR EACH ROW EXECUTE FUNCTION chat_messages_search_vector_update();
+
+CREATE TRIGGER chat_sessions_search_vector_update
+AFTER INSERT OR UPDATE ON chat_sessions
+FOR EACH ROW EXECUTE FUNCTION chat_sessions_search_vector_update();

--- a/server/migrations/2025-06-23-023453_update_session_updated_at/down.sql
+++ b/server/migrations/2025-06-23-023453_update_session_updated_at/down.sql
@@ -1,0 +1,3 @@
+DROP TRIGGER chat_messages_update_session_updated_at ON chat_messages;
+
+DROP FUNCTION chat_messages_update_session_updated_at ();

--- a/server/migrations/2025-06-23-023453_update_session_updated_at/up.sql
+++ b/server/migrations/2025-06-23-023453_update_session_updated_at/up.sql
@@ -1,0 +1,11 @@
+CREATE OR REPLACE FUNCTION chat_messages_update_session_updated_at () RETURNS TRIGGER AS $$
+BEGIN
+  UPDATE chat_sessions SET updated_at = NOW() WHERE id = NEW.session_id;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER chat_messages_update_session_updated_at BEFORE INSERT
+OR
+UPDATE ON chat_messages FOR EACH ROW
+EXECUTE FUNCTION chat_messages_update_session_updated_at ();

--- a/server/src/api/session.rs
+++ b/server/src/api/session.rs
@@ -18,7 +18,7 @@ use crate::{
     },
     errors::ApiError,
     redis::RedisClient,
-    utils::stored_stream::CACHE_KEY_PREFIX,
+    utils::{full_text_search::SessionSearchResult, stored_stream::CACHE_KEY_PREFIX},
 };
 
 pub fn get_routes(settings: &OpenApiSettings) -> (Vec<Route>, OpenApi) {
@@ -26,6 +26,7 @@ pub fn get_routes(settings: &OpenApiSettings) -> (Vec<Route>, OpenApi) {
         settings: get_all_sessions,
         create_session,
         get_session,
+        search_sessions,
         update_session,
         delete_session,
         delete_message
@@ -106,6 +107,21 @@ async fn get_session(
     }
 
     Ok(Json(GetSessionResponse { session, messages }))
+}
+
+/// Search chat sessions by title and messages
+#[openapi(tag = "Chat Session")]
+#[get("/search?<query>")]
+async fn search_sessions(
+    user: ChatRsUser,
+    mut db: DbConnection,
+    query: &str,
+) -> Result<Json<Vec<SessionSearchResult>>, ApiError> {
+    let sessions = ChatDbService::new(&mut db)
+        .search_sessions(&user.id, &query)
+        .await?;
+
+    Ok(Json(sessions))
 }
 
 #[derive(Deserialize, JsonSchema)]

--- a/server/src/db/schema.rs
+++ b/server/src/db/schema.rs
@@ -8,6 +8,10 @@ pub mod sql_types {
     #[derive(diesel::query_builder::QueryId, Clone, diesel::sql_types::SqlType)]
     #[diesel(postgres_type(name = "llm_provider"))]
     pub struct LlmProvider;
+
+    #[derive(diesel::query_builder::QueryId, Clone, diesel::sql_types::SqlType)]
+    #[diesel(postgres_type(name = "tsvector", schema = "pg_catalog"))]
+    pub struct Tsvector;
 }
 
 diesel::table! {
@@ -27,6 +31,7 @@ diesel::table! {
 diesel::table! {
     use diesel::sql_types::*;
     use super::sql_types::ChatMessageRole;
+    use super::sql_types::Tsvector;
 
     chat_messages (id) {
         id -> Uuid,
@@ -36,6 +41,7 @@ diesel::table! {
         created_at -> Timestamptz,
         updated_at -> Timestamptz,
         meta -> Jsonb,
+        search_vector -> Tsvector,
     }
 }
 

--- a/server/src/db/services/chat.rs
+++ b/server/src/db/services/chat.rs
@@ -67,7 +67,7 @@ impl<'a> ChatDbService<'a> {
         let sessions = chat_sessions::table
             .filter(chat_sessions::user_id.eq(user_id))
             .select(ChatRsSession::as_select())
-            .order_by(chat_sessions::created_at.desc())
+            .order_by(chat_sessions::updated_at.desc())
             .limit(100)
             .load(self.db)
             .await?;

--- a/server/src/utils.rs
+++ b/server/src/utils.rs
@@ -1,5 +1,6 @@
 pub mod create_provider;
 pub mod encryption;
+pub mod full_text_search;
 pub mod generate_title;
 pub mod json_logging;
 pub mod stored_stream;

--- a/server/src/utils/full_text_search.rs
+++ b/server/src/utils/full_text_search.rs
@@ -1,0 +1,71 @@
+use diesel::{prelude::QueryableByName, sql_query};
+use diesel_async::RunQueryDsl;
+use schemars::JsonSchema;
+use uuid::Uuid;
+
+use crate::db::DbConnection;
+
+/// Session matches for a full-text search query of chat titles and messages
+#[derive(Debug, Clone, QueryableByName, JsonSchema, serde::Serialize)]
+pub struct SessionSearchResult {
+    #[diesel(sql_type = diesel::sql_types::Uuid)]
+    pub session_id: Uuid,
+    #[diesel(sql_type = diesel::sql_types::Double)]
+    pub session_rank: f64,
+    #[diesel(sql_type = diesel::sql_types::BigInt)]
+    pub message_matches: i64,
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    pub title_highlight: String,
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    pub message_highlights: String,
+}
+
+/// Performs a full-text search of user's chat titles and messages
+pub async fn full_text_query(
+    conn: &mut DbConnection,
+    user_id: &Uuid,
+    query: &str,
+    limit: i32,
+) -> Result<Vec<SessionSearchResult>, diesel::result::Error> {
+    let results: Vec<SessionSearchResult> = sql_query(
+    r#"
+        WITH search_query AS (
+            SELECT plainto_tsquery('english', $1) AS query
+        ),
+        message_stats AS (
+            SELECT
+                cm.session_id,
+                cs.title,
+                cm.content,
+                ts_rank(cm.search_vector, sq.query) AS rank,
+                COUNT(*) OVER (PARTITION BY cm.session_id) AS message_matches,
+                ROW_NUMBER() OVER (
+                    PARTITION BY cm.session_id
+                    ORDER BY ts_rank(cm.search_vector, sq.query) DESC
+                ) AS rank_in_session
+            FROM chat_messages cm
+                JOIN chat_sessions cs ON cm.session_id = cs.id
+                CROSS JOIN search_query sq
+            WHERE cm.search_vector @@ sq.query
+                AND cs.user_id = $2
+        )
+        SELECT DISTINCT ON (session_id)
+            session_id,
+            rank * (1 + LOG(message_matches) * 0.1) AS session_rank,
+            message_matches,
+            ts_headline('english', title, sq.query, 'StartSel=<b>, StopSel=</b>, HighlightAll=true') AS title_highlight,
+            ts_headline('english', content, sq.query, 'StartSel=<b>, StopSel=</b>, MinWords=8, MaxWords=10, MaxFragments=2') AS message_highlights
+        FROM message_stats ms
+        CROSS JOIN search_query sq
+        WHERE rank_in_session = 1  -- Only best message per session
+        ORDER BY session_id, rank * (1 + LOG(message_matches) * 0.1) DESC
+        LIMIT $3;
+    "#,
+    )
+    .bind::<diesel::sql_types::Text, _>(query)
+    .bind::<diesel::sql_types::Uuid, _>(user_id)
+    .bind::<diesel::sql_types::Integer, _>(limit)
+    .load(conn).await?;
+
+    Ok(results)
+}

--- a/server/src/utils/full_text_search.rs
+++ b/server/src/utils/full_text_search.rs
@@ -53,8 +53,8 @@ pub async fn full_text_query(
             session_id,
             rank * (1 + LOG(message_matches) * 0.1) AS session_rank,
             message_matches,
-            ts_headline('english', title, sq.query, 'StartSel=<b>, StopSel=</b>, HighlightAll=true') AS title_highlight,
-            ts_headline('english', content, sq.query, 'StartSel=<b>, StopSel=</b>, MinWords=8, MaxWords=10, MaxFragments=2') AS message_highlights
+            ts_headline('english', title, sq.query, 'StartSel=§§§HIGHLIGHT_START§§§, StopSel=§§§HIGHLIGHT_END§§§, HighlightAll=true') AS title_highlight,
+            ts_headline('english', content, sq.query, 'StartSel=§§§HIGHLIGHT_START§§§, StopSel=§§§HIGHLIGHT_END§§§, MinWords=8, MaxWords=12, MaxFragments=3') AS message_highlights
         FROM message_stats ms
         CROSS JOIN search_query sq
         WHERE rank_in_session = 1  -- Only best message per session

--- a/server/src/utils/full_text_search.rs
+++ b/server/src/utils/full_text_search.rs
@@ -13,7 +13,7 @@ pub struct SessionSearchResult {
     #[diesel(sql_type = diesel::sql_types::Double)]
     pub session_rank: f64,
     #[diesel(sql_type = diesel::sql_types::Timestamptz)]
-    pub session_created_at: chrono::DateTime<chrono::Utc>,
+    pub session_updated_at: chrono::DateTime<chrono::Utc>,
     #[diesel(sql_type = diesel::sql_types::BigInt)]
     pub message_matches: i64,
     #[diesel(sql_type = diesel::sql_types::Text)]
@@ -38,7 +38,7 @@ pub async fn full_text_query(
             SELECT
                 cm.session_id,
                 cs.title,
-                cs.created_at,
+                cs.updated_at,
                 cm.content,
                 ts_rank(cm.search_vector, sq.query) AS rank,
                 COUNT(*) OVER (PARTITION BY cm.session_id) AS message_matches,
@@ -55,7 +55,7 @@ pub async fn full_text_query(
         SELECT DISTINCT ON (session_id)
             session_id,
             rank * (1 + LOG(message_matches) * 0.1) AS session_rank,
-            created_at AS session_created_at,
+            updated_at AS session_updated_at,
             message_matches,
             ts_headline('english', title, sq.query, 'StartSel=§§§HIGHLIGHT_START§§§, StopSel=§§§HIGHLIGHT_END§§§, HighlightAll=true') AS title_highlight,
             ts_headline('english', content, sq.query, 'StartSel=§§§HIGHLIGHT_START§§§, StopSel=§§§HIGHLIGHT_END§§§, MinWords=8, MaxWords=12, MaxFragments=3') AS message_highlights

--- a/server/src/utils/full_text_search.rs
+++ b/server/src/utils/full_text_search.rs
@@ -12,6 +12,8 @@ pub struct SessionSearchResult {
     pub session_id: Uuid,
     #[diesel(sql_type = diesel::sql_types::Double)]
     pub session_rank: f64,
+    #[diesel(sql_type = diesel::sql_types::Timestamptz)]
+    pub session_created_at: chrono::DateTime<chrono::Utc>,
     #[diesel(sql_type = diesel::sql_types::BigInt)]
     pub message_matches: i64,
     #[diesel(sql_type = diesel::sql_types::Text)]
@@ -36,6 +38,7 @@ pub async fn full_text_query(
             SELECT
                 cm.session_id,
                 cs.title,
+                cs.created_at,
                 cm.content,
                 ts_rank(cm.search_vector, sq.query) AS rank,
                 COUNT(*) OVER (PARTITION BY cm.session_id) AS message_matches,
@@ -52,6 +55,7 @@ pub async fn full_text_query(
         SELECT DISTINCT ON (session_id)
             session_id,
             rank * (1 + LOG(message_matches) * 0.1) AS session_rank,
+            created_at AS session_created_at,
             message_matches,
             ts_headline('english', title, sq.query, 'StartSel=§§§HIGHLIGHT_START§§§, StopSel=§§§HIGHLIGHT_END§§§, HighlightAll=true') AS title_highlight,
             ts_headline('english', content, sq.query, 'StartSel=§§§HIGHLIGHT_START§§§, StopSel=§§§HIGHLIGHT_END§§§, MinWords=8, MaxWords=12, MaxFragments=3') AS message_highlights

--- a/web/src/components/SearchDialog.tsx
+++ b/web/src/components/SearchDialog.tsx
@@ -78,6 +78,16 @@ export default function SearchDialog() {
 
 const HIGHLIGHT_REGEX = /§§§HIGHLIGHT_START§§§|§§§HIGHLIGHT_END§§§/g;
 
+const dateTimeFormatter = (date: Date) =>
+  new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+    year:
+      date.getUTCFullYear() === new Date().getUTCFullYear()
+        ? undefined
+        : "numeric",
+  }).format(date);
+
 function HighlightedResult({
   result,
 }: {
@@ -111,8 +121,15 @@ function HighlightedResult({
   );
 
   return (
-    <div className="flex flex-col">
-      <span>{highlightedTitle}</span>
+    <div className="flex flex-col flex-1 min-w-0">
+      <span className="flex justify-between">
+        <span className="text-nowrap overflow-hidden overflow-ellipsis">
+          {highlightedTitle}
+        </span>
+        <span className="text-muted-foreground text-nowrap">
+          {dateTimeFormatter(new Date(result.session_created_at))}
+        </span>
+      </span>
       <span className="text-xs text-muted-foreground">
         {highlightedMessage}
       </span>

--- a/web/src/components/SearchDialog.tsx
+++ b/web/src/components/SearchDialog.tsx
@@ -1,0 +1,56 @@
+import { CommandLoading } from "cmdk";
+import { useEffect, useState } from "react";
+import { useDebounce } from "use-debounce";
+
+import { useSearchChats } from "@/lib/api/search";
+import {
+  CommandDialog,
+  CommandEmpty,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "./ui/command";
+
+export default function SearchDialog() {
+  const [open, setOpen] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [debouncedQuery, debounceMeta] = useDebounce(searchQuery, 300, {
+    trailing: true,
+  });
+
+  const { data, isFetching } = useSearchChats(debouncedQuery);
+
+  // Handle command-k triggered
+  useEffect(() => {
+    const down = (e: KeyboardEvent) => {
+      if (e.key === "k" && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        setOpen((open) => !open);
+      }
+    };
+    document.addEventListener("keydown", down);
+    return () => document.removeEventListener("keydown", down);
+  }, []);
+
+  return (
+    <CommandDialog open={open} onOpenChange={setOpen} shouldFilter={false}>
+      <CommandInput onValueChange={setSearchQuery} />
+      <CommandList>
+        {(isFetching || debounceMeta.isPending()) && (
+          <CommandLoading className="p-3" progress={50}>
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-muted-foreground"></div>
+              Searching for '{searchQuery}'...
+            </div>
+          </CommandLoading>
+        )}
+        {!(isFetching || debounceMeta.isPending()) && (
+          <CommandEmpty>No results</CommandEmpty>
+        )}
+        {data?.map((item) => (
+          <CommandItem key={item}>{item}</CommandItem>
+        ))}
+      </CommandList>
+    </CommandDialog>
+  );
+}

--- a/web/src/components/SearchDialog.tsx
+++ b/web/src/components/SearchDialog.tsx
@@ -34,7 +34,10 @@ export default function SearchDialog() {
 
   return (
     <CommandDialog open={open} onOpenChange={setOpen} shouldFilter={false}>
-      <CommandInput onValueChange={setSearchQuery} />
+      <CommandInput
+        placeholder="Search chats..."
+        onValueChange={setSearchQuery}
+      />
       <CommandList>
         {(isFetching || debounceMeta.isPending()) && (
           <CommandLoading className="p-3" progress={50}>
@@ -44,11 +47,20 @@ export default function SearchDialog() {
             </div>
           </CommandLoading>
         )}
-        {!(isFetching || debounceMeta.isPending()) && (
+        {searchQuery && !(isFetching || debounceMeta.isPending()) && (
           <CommandEmpty>No results</CommandEmpty>
         )}
-        {data?.map((item) => (
-          <CommandItem key={item}>{item}</CommandItem>
+        {data?.map((result) => (
+          <CommandItem
+            key={result.session_id}
+            className="flex flex-col items-start gap-0.5"
+            value={result.session_id}
+          >
+            <div>{result.title_highlight}</div>
+            <div className="text-xs text-muted-foreground">
+              {result.message_highlights}
+            </div>
+          </CommandItem>
         ))}
       </CommandList>
     </CommandDialog>

--- a/web/src/components/SearchDialog.tsx
+++ b/web/src/components/SearchDialog.tsx
@@ -127,7 +127,7 @@ function HighlightedResult({
           {highlightedTitle}
         </span>
         <span className="text-muted-foreground text-nowrap">
-          {dateTimeFormatter(new Date(result.session_created_at))}
+          {dateTimeFormatter(new Date(result.session_updated_at))}
         </span>
       </span>
       <span className="text-xs text-muted-foreground">

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -204,8 +204,8 @@ export function AppSidebar({
                               </span>
                               <span className="shrink-0 text-muted-foreground ml-auto">
                                 {group === "today" || group === "yesterday"
-                                  ? formatTime(session.created_at)
-                                  : formatDate(session.created_at)}
+                                  ? formatTime(session.updated_at)
+                                  : formatDate(session.updated_at)}
                               </span>
                             </Link>
                           </SidebarMenuSubButton>
@@ -258,7 +258,7 @@ function groupSessionsByDate(
   };
 
   sessions?.forEach((session) => {
-    const sessionDate = new Date(session.created_at);
+    const sessionDate = new Date(session.updated_at);
     const sessionDateOnly = new Date(
       sessionDate.getFullYear(),
       sessionDate.getMonth(),

--- a/web/src/components/ui/command.tsx
+++ b/web/src/components/ui/command.tsx
@@ -1,5 +1,3 @@
-"use client"
-
 import * as React from "react"
 import { Command as CommandPrimitive } from "cmdk"
 import { SearchIcon } from "lucide-react"
@@ -35,12 +33,14 @@ function CommandDialog({
   children,
   className,
   showCloseButton = true,
+  shouldFilter = true,
   ...props
 }: React.ComponentProps<typeof Dialog> & {
   title?: string
   description?: string
   className?: string
-  showCloseButton?: boolean
+  showCloseButton?: boolean,
+  shouldFilter?: boolean,
 }) {
   return (
     <Dialog {...props}>
@@ -52,7 +52,8 @@ function CommandDialog({
         className={cn("overflow-hidden p-0", className)}
         showCloseButton={showCloseButton}
       >
-        <Command className="[&_[cmdk-group-heading]]:text-muted-foreground **:data-[slot=command-input-wrapper]:h-12 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group]]:px-2 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
+        <Command className="[&_[cmdk-group-heading]]:text-muted-foreground **:data-[slot=command-input-wrapper]:h-12 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group]]:px-2 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5"
+          shouldFilter={shouldFilter}>
           {children}
         </Command>
       </DialogContent>

--- a/web/src/lib/api/search.ts
+++ b/web/src/lib/api/search.ts
@@ -1,19 +1,18 @@
 import { useQuery } from "@tanstack/react-query";
 
+import { client } from "./client";
+
 export const useSearchChats = (searchQuery?: string) =>
   useQuery({
     staleTime: 10 * 1000, // 10 seconds
-    enabled: !!searchQuery,
     queryKey: ["search", { query: searchQuery }] as const,
     queryFn: async ({ queryKey: [_, { query }] }) => {
-      console.log(`Searching chats for '${query}'`);
-      await new Promise((r) => setTimeout(r, 600));
-      return [
-        `${searchQuery} 1`,
-        `${searchQuery} 2`,
-        `${searchQuery} other`,
-        `${searchQuery} 4`,
-      ];
+      if (!query) return [];
+      const res = await client.GET("/session/search", {
+        params: { query: { query } },
+      });
+      if (res.error) throw new Error(res.error.message);
+      return res.data;
     },
     placeholderData: (prev) => prev,
   });

--- a/web/src/lib/api/search.ts
+++ b/web/src/lib/api/search.ts
@@ -1,0 +1,19 @@
+import { useQuery } from "@tanstack/react-query";
+
+export const useSearchChats = (searchQuery?: string) =>
+  useQuery({
+    staleTime: 10 * 1000, // 10 seconds
+    enabled: !!searchQuery,
+    queryKey: ["search", { query: searchQuery }] as const,
+    queryFn: async ({ queryKey: [_, { query }] }) => {
+      console.log(`Searching chats for '${query}'`);
+      await new Promise((r) => setTimeout(r, 600));
+      return [
+        `${searchQuery} 1`,
+        `${searchQuery} 2`,
+        `${searchQuery} other`,
+        `${searchQuery} 4`,
+      ];
+    },
+    placeholderData: (prev) => prev,
+  });

--- a/web/src/lib/api/types.d.ts
+++ b/web/src/lib/api/types.d.ts
@@ -62,7 +62,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** List chat sessions */
+        /** @description List chat sessions */
         get: operations["get_all_sessions"];
         put?: never;
         /** @description Create a new chat session */
@@ -90,6 +90,23 @@ export interface paths {
         head?: never;
         /** @description Update chat session */
         patch: operations["update_session"];
+        trace?: never;
+    };
+    "/session/search": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description Search chat sessions by title and messages */
+        get: operations["search_sessions"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
         trace?: never;
     };
     "/session/{session_id}/{message_id}": {
@@ -233,6 +250,17 @@ export interface components {
             temperature?: number | null;
             /** Format: uint32 */
             max_tokens?: number | null;
+        };
+        /** @description Session matches for a full-text search query of chat titles and messages */
+        SessionSearchResult: {
+            /** Format: uuid */
+            session_id: string;
+            /** Format: double */
+            session_rank: number;
+            /** Format: int64 */
+            message_matches: number;
+            title_highlight: string;
+            message_highlights: string;
         };
         UpdateSessionInput: {
             title: string;
@@ -693,6 +721,72 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["SessionIdResponse"];
+                };
+            };
+            /** @description Bad request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Message"];
+                };
+            };
+            /** @description Authentication error */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Message"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Message"];
+                };
+            };
+            /** @description Incorrectly formatted */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Message"];
+                };
+            };
+            /** @description Internal error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Message"];
+                };
+            };
+        };
+    };
+    search_sessions: {
+        parameters: {
+            query: {
+                query: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SessionSearchResult"][];
                 };
             };
             /** @description Bad request */

--- a/web/src/lib/api/types.d.ts
+++ b/web/src/lib/api/types.d.ts
@@ -258,7 +258,7 @@ export interface components {
             /** Format: double */
             session_rank: number;
             /** Format: date-time */
-            session_created_at: string;
+            session_updated_at: string;
             /** Format: int64 */
             message_matches: number;
             title_highlight: string;

--- a/web/src/lib/api/types.d.ts
+++ b/web/src/lib/api/types.d.ts
@@ -257,6 +257,8 @@ export interface components {
             session_id: string;
             /** Format: double */
             session_rank: number;
+            /** Format: date-time */
+            session_created_at: string;
             /** Format: int64 */
             message_matches: number;
             title_highlight: string;

--- a/web/src/routes/app/_appLayout.tsx
+++ b/web/src/routes/app/_appLayout.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, Outlet, redirect } from "@tanstack/react-router";
 
 import ErrorComponent from "@/components/Error";
 import Header from "@/components/Header";
+import SearchDialog from "@/components/SearchDialog";
 import { AppSidebar } from "@/components/Sidebar";
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
 import {
@@ -43,6 +44,7 @@ function RouteComponent() {
 
   return (
     <SidebarProvider>
+      <SearchDialog />
       <AppSidebar user={user} sessions={data} streamedChats={streamedChats} />
       <SidebarInset className="overflow-hidden">
         <Header />


### PR DESCRIPTION
- This adds full text search of chat titles and messages, with a search dialog on the frontend (using `cmdk` for convenient keyboard access).
- This also adds a Postgres trigger to automatically update the chat session `updated_at` property on new messages. In the web frontend, this will surface chats with most recent messages to the top of the sidebar.