### PR TITLE
fix: tweak prose styles for better Markdown fit within chat bubbles

### DIFF
--- a/web/src/components/chat/ChatFancyMarkdown.tsx
+++ b/web/src/components/chat/ChatFancyMarkdown.tsx
@@ -70,22 +70,22 @@ function CodeWrapper({ children }: { children?: ReactNode }) {
 
   if (!children) return null;
   return (
-    <div className="not-prose">
+    <div className="not-prose relative">
       {/* `not-prose` disables the Tailwind typography styles */}
-      <pre ref={ref} className="relative text-xs md:text-sm">
-        <Button
-          className="absolute top-1 md:top-2 right-1 md:right-2 opacity-85 hover:opacity-100"
-          onClick={handleCopy}
-          variant="outline"
-          size="sm"
-        >
-          {isCopied ? (
-            <Check className="size-4 text-green-600" />
-          ) : (
-            <Copy className="size-3" />
-          )}
-          Copy
-        </Button>
+      <Button
+        aria-label="Copy code"
+        className="absolute top-1 right-1 size-8 text-muted-foreground opacity-75 hover:opacity-100"
+        onClick={handleCopy}
+        variant="outline"
+        size="icon"
+      >
+        {isCopied ? (
+          <Check className="size-5 text-green-600" />
+        ) : (
+          <Copy className="size-4" />
+        )}
+      </Button>
+      <pre ref={ref} className="text-xs md:text-sm overflow-x-auto">
         {children}
       </pre>
     </div>

--- a/web/src/components/chat/ChatFancyMarkdown.tsx
+++ b/web/src/components/chat/ChatFancyMarkdown.tsx
@@ -74,7 +74,7 @@ function CodeWrapper({ children }: { children?: ReactNode }) {
       {/* `not-prose` disables the Tailwind typography styles */}
       <Button
         aria-label="Copy code"
-        className="absolute top-1 right-1 size-8 text-muted-foreground opacity-75 hover:opacity-100"
+        className="absolute top-1 right-1 size-8 text-muted-foreground opacity-75 hover:opacity-100 focus-visible:opacity-100"
         onClick={handleCopy}
         variant="outline"
         size="icon"

--- a/web/src/components/chat/ChatMessages.tsx
+++ b/web/src/components/chat/ChatMessages.tsx
@@ -25,7 +25,8 @@ interface Props {
 }
 
 const proseClasses =
-  "prose prose-sm md:prose-base dark:prose-invert prose-pre:bg-primary-foreground prose-hr:my-3 prose-li:my-1";
+  "prose prose-sm md:prose-base dark:prose-invert prose-pre:bg-primary-foreground prose-hr:my-3 prose-headings:not-[:first-child]:mt-3 prose-headings:mb-2 " +
+  "prose-h1:text-3xl prose-ul:my-3 prose-ol:my-3 prose-p:leading-4 md:prose-p:leading-5.5 prose-li:my-1 prose-li:leading-4 md:prose-li:leading-5.5";
 const proseUserClasses = "prose-code:text-primary-foreground";
 const proseAssistantClasses = "prose-code:text-secondary-foreground";
 


### PR DESCRIPTION
- Fix: tweaked the Tailwind prose styles (margin, font size, etc.) to better fit Markdown content within the chat bubbles
- Fix: plaintext code blocks are now scrollable
- Fix: copy code button is now an icon button to avoid blocking code (with `aria-label` for accessibility)

### Before:
![CleanShot 2025-06-24 at 21 30 37@2x](https://github.com/user-attachments/assets/fe511ee5-7dcd-4230-8098-16a24c45fb97)

### After:

![CleanShot 2025-06-24 at 21 29 35@2x](https://github.com/user-attachments/assets/3c153592-0147-4b5b-92d6-a1a4a2ea60e8)
